### PR TITLE
BREAKING: Changing keyboard shortcuts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,11 +87,13 @@ To quit in Windows, toggle the app unlocked and right-click > `Close`.
 
 Description            | Keys
 -----------------------| -----------------------
-Toggle the settings window and lock the crosshair in place | <kbd>Control</kbd><kbd>Shift</kbd><kbd>X</kbd>
-Quickly hide/show the application                          | <kbd>Control</kbd><kbd>Shift</kbd><kbd>E</kbd>
-Reset all settings and center the window                   | <kbd>Control</kbd><kbd>Shift</kbd><kbd>R</kbd>
-Display the "About" window details                        | <kbd>Control</kbd><kbd>Shift</kbd><kbd>A</kbd>
-Move the crosshair a single pixel                          | <kbd>Control</kbd><kbd>Shift</kbd><kbd>Arrows</kbd>
+Toggle the settings window and lock the crosshair in place | <kbd>Control</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>X</kbd>
+Quickly hide/show the application                          | <kbd>Control</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>E</kbd>
+Reset all settings and center the window                   | <kbd>Control</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>R</kbd>
+Display the "About" window details                        | <kbd>Control</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>A</kbd>
+Move the crosshair a single pixel                          | <kbd>Control</kbd><kbd>Alt</kbd><kbd>Shift</kbd><kbd>Arrows</kbd>
+
+###### <kbd>Option</kbd> is <kbd>Alt</kbd> on a Mac
 
 <p align="center">
 	<br />

--- a/src/main.js
+++ b/src/main.js
@@ -325,7 +325,7 @@ app.on('ready', () => {
 	/* Global KeyListners */
 
 	// Toggle CrossOver
-	globalShortcut.register('Control+Shift+X', () => {
+	globalShortcut.register('Control+Shift+Alt+X', () => {
 		toggleWindowLock()
 	})
 	globalShortcut.register('CommandOrControl+,', () => {
@@ -333,31 +333,31 @@ app.on('ready', () => {
 	})
 
 	// Hide CrossOver
-	globalShortcut.register('Control+Shift+E', () => {
+	globalShortcut.register('Control+Shift+Alt+E', () => {
 		hideWindow()
 	})
 
 	// Reset CrossOver
-	globalShortcut.register('Control+Shift+R', () => {
+	globalShortcut.register('Control+Shift+Alt+R', () => {
 		resetSettings()
 	})
 
 	// About CrossOver
-	globalShortcut.register('Control+Shift+A', () => {
+	globalShortcut.register('Control+Shift+Alt+A', () => {
 		aboutWindow()
 	})
 
 	// Single pixel movement
-	globalShortcut.register('Control+Shift+Up', () => {
+	globalShortcut.register('Control+Shift+Alt+Up', () => {
 		moveWindow('up')
 	})
-	globalShortcut.register('Control+Shift+Down', () => {
+	globalShortcut.register('Control+Shift+Alt+Down', () => {
 		moveWindow('down')
 	})
-	globalShortcut.register('Control+Shift+Left', () => {
+	globalShortcut.register('Control+Shift+Alt+Left', () => {
 		moveWindow('left')
 	})
-	globalShortcut.register('Control+Shift+Right', () => {
+	globalShortcut.register('Control+Shift+Alt+Right', () => {
 		moveWindow('right')
 	})
 })

--- a/src/menu.js
+++ b/src/menu.js
@@ -161,28 +161,28 @@ const macosTemplate = [
 		submenu: [
 			{
 				label: 'Move Up',
-				accelerator: 'Control+Shift+Up',
+				accelerator: 'Control+Shift+Alt+Up',
 				click() {
 					moveWindow('up')
 				}
 			},
 			{
 				label: 'Move Down',
-				accelerator: 'Control+Shift+Down',
+				accelerator: 'Control+Shift+Alt+Down',
 				click() {
 					moveWindow('down')
 				}
 			},
 			{
 				label: 'Move Left',
-				accelerator: 'Control+Shift+Left',
+				accelerator: 'Control+Shift+Alt+Left',
 				click() {
 					moveWindow('left')
 				}
 			},
 			{
 				label: 'Move Right',
-				accelerator: 'Control+Shift+Right',
+				accelerator: 'Control+Shift+Alt+Right',
 				click() {
 					moveWindow('right')
 				}


### PR DESCRIPTION
There has been feedback of accidentally triggering a reset of the app while gaming (big no-no), so I'm making it harder to trigger.

Key combos now require `Alt`, making the main crosshair combo CTRL-ALT-SHIFT-X

Readme has been updated