### PR TITLE
bump 2.16, Fixes #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "crossover",
 	"productName": "CrossOver",
-	"version": "0.2.15",
+	"version": "0.2.16",
 	"description": "🎯 A Crosshair Overlay for any screen",
 	"license": "MIT",
 	"repository": "lacymorrow/crossover",


### PR DESCRIPTION
Fixes issue where Color picker is not within app bounds.

Fixes help info keyboard shortcut.