### PR TITLE
fix: lock state not persisting across quit/restart on Windows

### DIFF
--- a/src/main/init.js
+++ b/src/main/init.js
@@ -59,14 +59,24 @@ const init = async options => {
 
 	crossover.resetPosition()
 
-	// Set lock state, timeout makes it pretty
-	setTimeout( () => {
+	// Set lock state after renderer is ready
+	// Using did-finish-load ensures the renderer's IPC listeners are registered
+	// before we send lock_window. The 400ms timeout was unreliable on Windows (#480).
+	let lockStateInitialized = false
+	const setupLockState = () => {
 
-		// Todo: We shouldn't need a timeout here
-		// Keyboard shortcuts - delay fixes an unbreakable loop on reset, continually triggering resets
+		if ( lockStateInitialized ) {
+
+			return
+
+		}
+
+		lockStateInitialized = true
+
+		// Keyboard shortcuts (delay from did-finish-load avoids the reset loop)
 		crossover.registerKeyboardShortcuts()
 
-		// Show or hide window
+		// Restore lock state
 		crossover.lockWindow( preferences.value( 'hidden.locked' ) )
 
 		ipcMain.once( 'init', () => {
@@ -76,7 +86,37 @@ const init = async options => {
 
 		} )
 
-	}, 400 )
+	}
+
+	if ( windows.win && windows.win.webContents ) {
+
+		if ( options?.triggeredByReset ) {
+
+			// Reset case: page is already loaded, small delay to avoid the reset loop
+			setTimeout( setupLockState, 100 )
+
+		} else if ( windows.win.webContents.isLoading() ) {
+
+			// First boot: wait for renderer to finish loading
+			windows.win.webContents.once( 'did-finish-load', () => {
+
+				setTimeout( setupLockState, 50 )
+
+			} )
+
+		} else {
+
+			// Page already loaded
+			setTimeout( setupLockState, 50 )
+
+		}
+
+	} else {
+
+		// Fallback
+		setTimeout( setupLockState, 400 )
+
+	}
 
 	// Spawn chooser window (if resetting it may exist)
 	if ( !windows.chooserWindow ) {

--- a/src/main/init.js
+++ b/src/main/init.js
@@ -95,19 +95,21 @@ const init = async options => {
 			// Reset case: page is already loaded, small delay to avoid the reset loop
 			setTimeout( setupLockState, 100 )
 
-		} else if ( windows.win.webContents.isLoading() ) {
-
-			// First boot: wait for renderer to finish loading
-			windows.win.webContents.once( 'did-finish-load', () => {
-
-				setTimeout( setupLockState, 50 )
-
-			} )
-
 		} else {
 
-			// Page already loaded
-			setTimeout( setupLockState, 50 )
+			const scheduleSetup = () => setTimeout( setupLockState, 50 )
+
+			if ( windows.win.webContents.isLoading() ) {
+
+				// First boot: wait for renderer to finish loading
+				windows.win.webContents.once( 'did-finish-load', scheduleSetup )
+
+			} else {
+
+				// Page already loaded
+				scheduleSetup()
+
+			}
 
 		}
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -60,13 +60,39 @@ const appEvents = () => {
 	// See https://github.com/electron/electron/issues/5273
 	app.on( 'before-quit', () => {
 
+		// Unlock the window before quitting so it can properly close on Windows
+		// When locked, closable=false prevents the window from being destroyed,
+		// leaving a zombie process (see #480)
+		const win = windows.win
+		if ( win && !win.isDestroyed() ) {
+
+			win.closable = true
+			win.setFocusable( true )
+			win.setIgnoreMouseEvents( false )
+
+		}
+
+		// Also unlock shadow windows
+		for ( const shadowWin of windows.shadowWindows ) {
+
+			if ( shadowWin && !shadowWin.isDestroyed() ) {
+
+				shadowWin.closable = true
+				shadowWin.setFocusable( true )
+				shadowWin.setIgnoreMouseEvents( false )
+
+			}
+
+		}
+
 		app.releaseSingleInstanceLock()
 
 	} )
 
 	app.on( 'will-quit', () => {
 
-		// Unregister all shortcuts.
+		// Save lock state before cleanup so it persists for next launch
+		// Then unregister all hooks and shortcuts
 		iohook.unregisterIOHook()
 		keyboard.unregisterShortcuts()
 		// process.exit( EXIT_CODES.SUCCESS )

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -60,30 +60,23 @@ const appEvents = () => {
 	// See https://github.com/electron/electron/issues/5273
 	app.on( 'before-quit', () => {
 
-		// Unlock the window before quitting so it can properly close on Windows
+		// Unlock all windows before quitting so they can properly close on Windows
 		// When locked, closable=false prevents the window from being destroyed,
 		// leaving a zombie process (see #480)
-		const win = windows.win
-		if ( win && !win.isDestroyed() ) {
+		const makeWindowClosable = win => {
 
-			win.closable = true
-			win.setFocusable( true )
-			win.setIgnoreMouseEvents( false )
+			if ( win && !win.isDestroyed() ) {
 
-		}
-
-		// Also unlock shadow windows
-		for ( const shadowWin of windows.shadowWindows ) {
-
-			if ( shadowWin && !shadowWin.isDestroyed() ) {
-
-				shadowWin.closable = true
-				shadowWin.setFocusable( true )
-				shadowWin.setIgnoreMouseEvents( false )
+				win.closable = true
+				win.setFocusable( true )
+				win.setIgnoreMouseEvents( false )
 
 			}
 
 		}
+
+		makeWindowClosable( windows.win )
+		windows.shadowWindows.forEach( makeWindowClosable )
 
 		app.releaseSingleInstanceLock()
 


### PR DESCRIPTION
Closes #480

**Problem:**
When CrossOver is quit from the tray while the crosshair is locked, the process stays alive as a zombie on Windows (portable builds). The locked window has `closable = false`, which prevents Electron from destroying it during quit. On next launch, the keybind fires (plays sound) but lock state is out of sync because the old process still holds the global shortcut.

**Root cause:**
1. `lockWindow(true)` sets `closable = false` on the BrowserWindow
2. Tray quit triggers `app.quit()`, but Electron can't close a window with `closable = false`
3. The process lingers, holding onto global shortcuts
4. On restart, the init sequence used a fragile 400ms `setTimeout` to send `lock_window` to the renderer, which could fire before the renderer's IPC listeners were ready

**Fix:**
1. **`before-quit` handler** (register.js): Reset `closable`, `focusable`, and `ignoreMouseEvents` on all windows (main + shadows) so Electron can properly destroy them
2. **`init.js`**: Replace the 400ms timeout with `webContents.once('did-finish-load')` to ensure the renderer is ready before restoring lock state. Includes a guard against double-initialization and proper fallback paths for reset vs first boot scenarios