### PR TITLE
fix: stop IOHook before window destruction to prevent crash on quit

### DIFF
--- a/src/main/iohook.js
+++ b/src/main/iohook.js
@@ -196,6 +196,12 @@ const followMouse = async () => {
 
 	const listener = event => {
 
+		if ( !windows.win || windows.win.isDestroyed() ) {
+
+			return
+
+		}
+
 		windows.win.setBounds( {
 			x: event.x - Math.round( width / 2 ),
 			y: event.y - Math.round( height / 2 ),

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -60,6 +60,11 @@ const appEvents = () => {
 	// See https://github.com/electron/electron/issues/5273
 	app.on( 'before-quit', () => {
 
+		// Stop IOHook before windows close so in-flight events (e.g. mousemove
+		// for followMouse) can't call setBounds on a destroyed window and trigger
+		// an ObjC exception crash (EXC_BAD_INSTRUCTION via _crashOnException).
+		iohook.unregisterIOHook()
+
 		// Unlock all windows before quitting so they can properly close on Windows
 		// When locked, closable=false prevents the window from being destroyed,
 		// leaving a zombie process (see #480)

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -89,9 +89,7 @@ const appEvents = () => {
 
 	app.on( 'will-quit', () => {
 
-		// Save lock state before cleanup so it persists for next launch
-		// Then unregister all hooks and shortcuts
-		iohook.unregisterIOHook()
+		// IOHook already stopped in before-quit; just clean up keyboard shortcuts
 		keyboard.unregisterShortcuts()
 		// process.exit( EXIT_CODES.SUCCESS )
 

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -536,6 +536,12 @@ const onWillResize = ( _event, newBounds ) => {
 // Prevent opening windows off-screen; Must pass width/height to set safely
 const safeSetBounds = ( win, bounds ) => {
 
+	if ( !win || win.isDestroyed() ) {
+
+		return
+
+	}
+
 	let currentBounds
 	if ( !( bounds.width && bounds.height ) ) {
 


### PR DESCRIPTION
## Root cause

Analyzed the crash log from issue #474. The crash signature is `EXC_BAD_INSTRUCTION` / `SIGILL` via `NSApplication _crashOnException`, triggered when an ObjC exception propagates uncaught from an Electron window API call.

The stack confirms:
- Thread 196430 (unnamed) was running `hook_run` / `hook_thread_proc` (uiohook active)
- Thread 196162 (CrBrowserMain, triggered) crashed through `_crashOnException`

**Race condition**: When CrossOver quits while locked with followMouse active:
1. `before-quit` fires — makes windows closable, releases lock
2. Window starts closing and gets destroyed
3. uiohook `mousemove` event fires (IOHook still running)
4. `followMouse` listener calls `windows.win.setBounds()` on the destroyed window
5. Cocoa throws an ObjC exception → `_crashOnException` → SIGILL

IOHook was only stopped in `will-quit`, which fires *after* all windows close — too late.

Same pattern explains why quitting registers as a crash ~50% of the time (timing-dependent race).

## Fix (three layers)

1. **Call `unregisterIOHook()` in `before-quit`** — stops IOHook *before* windows close, eliminating the race at the source
2. **Add `isDestroyed()` guard in `followMouse` listener** — defensive fallback in case of any other timing edge case
3. **Add `isDestroyed()` guard in `safeSetBounds`** — protects all other callers from the same class of bug

## Test plan

- [ ] Lock CrossOver, enable follow mouse, quit — no crash
- [ ] Lock CrossOver, quit normally (CMD+Q / menu) — no crash report in Console.app
- [ ] Force quit while locked — no crash report
- [ ] Unlock, quit — normal behavior unchanged

Closes #474