### PR TITLE
fix: deny all browser permission requests to prevent OS prompts

### DIFF
--- a/src/main/register.js
+++ b/src/main/register.js
@@ -1,4 +1,4 @@
-const { app } = require( 'electron' )
+const { app, session } = require( 'electron' )
 const { is } = require( './util' )
 const crossover = require( './crossover' )
 const preferences = require( './preferences' ).init()
@@ -9,6 +9,15 @@ const reset = require( './reset' )
 const windows = require( './windows' )
 
 const appEvents = () => {
+
+	// CrossOver only renders local files and needs no browser permissions.
+	// Deny all permission requests (geolocation, notifications, camera, etc.)
+	// to prevent unexpected OS prompts, particularly on Windows. (#471)
+	session.defaultSession.setPermissionRequestHandler( ( _webContents, _permission, callback ) => {
+
+		callback( false )
+
+	} )
 
 	app.on( 'activate', async () => {
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -19,6 +19,8 @@ const appEvents = () => {
 
 	} )
 
+	session.defaultSession.setPermissionCheckHandler( () => false )
+
 	app.on( 'activate', async () => {
 
 		// Will return current window if exists


### PR DESCRIPTION
## Problem

Reported in issue #471: Windows users see an OS location permission prompt when running CrossOver.

CrossOver only renders local HTML/CSS files and has no use for any browser permission (geolocation, camera, notifications, etc.). Without a `setPermissionRequestHandler`, Electron forwards any permission requests from the renderer to the OS — on Windows this pops a system dialog asking the user to share their location.

## Fix

Add a deny-all `setPermissionRequestHandler` on `session.defaultSession` at app startup. Any permission request from any webContents will be immediately denied without an OS prompt.

```js
session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
    callback(false)
})
```

## Test plan

- [ ] Start CrossOver on Windows, confirm no location permission prompt appears
- [ ] All existing features (lock, follow mouse, ADS resize) still work normally
- [ ] Mac build unaffected

Closes #471