### PR TITLE
fix: force process.exit on quit and safe GPU settings on --reset

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,7 +115,7 @@ const start = async () => {
 
 	// When resetting, force safe GPU settings so the GPU process doesn't crash
 	// before the reset logic can run. (#450)
-	if ( process.env.CROSSOVER_RESET ) {
+	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
 
 		log.info( 'Reset mode: forcing safe GPU settings' )
 		app.commandLine.appendSwitch( 'disable-gpu' )
@@ -163,7 +163,7 @@ const ready = async () => {
 	log.info( 'App ready' )
 
 	// Allow command-line reset
-	if ( process.env.CROSSOVER_RESET ) {
+	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
 
 		log.info( 'Command-line reset triggered' )
 		reset.app( true )

--- a/src/main.js
+++ b/src/main.js
@@ -113,31 +113,43 @@ const start = async () => {
 	/* LINUX FIXES */
 	// More flags: https://www.electronjs.org/docs/latest/api/command-line-switches/
 
-	// Disable hardware acceleration
-	if ( checkboxTrue( preferences.value( 'app.gpu' ), 'gpu' ) ) {
+	// When resetting, force safe GPU settings so the GPU process doesn't crash
+	// before the reset logic can run. (#450)
+	if ( process.env.CROSSOVER_RESET ) {
 
-		log.info( 'Setting: Enable GPU' )
+		log.info( 'Reset mode: forcing safe GPU settings' )
+		app.commandLine.appendSwitch( 'disable-gpu' )
+		app.disableHardwareAcceleration()
 
 	} else {
 
 		// Disable hardware acceleration
-		log.info( 'Setting: Disable GPU' )
-		app.commandLine.appendSwitch( 'enable-transparent-visuals' )
-		app.commandLine.appendSwitch( 'disable-gpu' )
-		app.disableHardwareAcceleration()
+		if ( checkboxTrue( preferences.value( 'app.gpu' ), 'gpu' ) ) {
 
-	}
+			log.info( 'Setting: Enable GPU' )
 
-	// Fix for Linux transparency issues: wayland on linux/sway
-	// This switch runs the GPU process in the same process as the browser, which can help avoid the issues with transparency.
-	// https://github.com/microsoft/vscode/issues/146464
-	// https://www.electronjs.org/docs/latest/api/command-line-switches/#in-process-gpu
-	if ( !checkboxTrue( preferences.value( 'app.gpuprocess' ), 'gpuprocess' ) ) {
+		} else {
 
-		log.info( 'Setting: Sharing GPU process and browser' )
+			// Disable hardware acceleration
+			log.info( 'Setting: Disable GPU' )
+			app.commandLine.appendSwitch( 'enable-transparent-visuals' )
+			app.commandLine.appendSwitch( 'disable-gpu' )
+			app.disableHardwareAcceleration()
 
-		app.commandLine.appendSwitch( 'in-process-gpu' )
-		app.commandLine.appendSwitch( 'use-gl=desktop' )
+		}
+
+		// Fix for Linux transparency issues: wayland on linux/sway
+		// This switch runs the GPU process in the same process as the browser, which can help avoid the issues with transparency.
+		// https://github.com/microsoft/vscode/issues/146464
+		// https://www.electronjs.org/docs/latest/api/command-line-switches/#in-process-gpu
+		if ( !checkboxTrue( preferences.value( 'app.gpuprocess' ), 'gpuprocess' ) ) {
+
+			log.info( 'Setting: Sharing GPU process and browser' )
+
+			app.commandLine.appendSwitch( 'in-process-gpu' )
+			app.commandLine.appendSwitch( 'use-gl=desktop' )
+
+		}
 
 	}
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -7,6 +7,7 @@ const keyboard = require( './keyboard' )
 const log = require( './log' )
 const reset = require( './reset' )
 const windows = require( './windows' )
+const EXIT_CODES = require( '../config/exit-codes' )
 
 const appEvents = () => {
 
@@ -84,11 +85,12 @@ const appEvents = () => {
 
 	app.on( 'will-quit', () => {
 
-		// Save lock state before cleanup so it persists for next launch
-		// Then unregister all hooks and shortcuts
+		// Unregister all hooks and shortcuts, then force-exit to prevent
+		// lingering handles (timers, native modules) from keeping the process
+		// alive after the user quits. (#486)
 		iohook.unregisterIOHook()
 		keyboard.unregisterShortcuts()
-		// process.exit( EXIT_CODES.SUCCESS )
+		process.exit( EXIT_CODES.SUCCESS )
 
 	} )
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -88,9 +88,16 @@ const appEvents = () => {
 		// Unregister all hooks and shortcuts, then force-exit to prevent
 		// lingering handles (timers, native modules) from keeping the process
 		// alive after the user quits. (#486)
-		iohook.unregisterIOHook()
-		keyboard.unregisterShortcuts()
-		process.exit( EXIT_CODES.SUCCESS )
+		try {
+
+			iohook.unregisterIOHook()
+			keyboard.unregisterShortcuts()
+
+		} finally {
+
+			app.exit( EXIT_CODES.SUCCESS )
+
+		}
 
 	} )
 


### PR DESCRIPTION
## Summary

- **#486** — App stays open in background after close: added `process.exit(EXIT_CODES.SUCCESS)` in the `will-quit` handler so lingering handles (the `setInterval` in auto-update, `uiohook-napi` native module) cannot keep the process alive after the user quits.
- **#450** — `--reset` doesn't work on Linux when GPU preference causes crash: when `CROSSOVER_RESET` env var is set, GPU preferences are bypassed and `disable-gpu` is forced, so the GPU process cannot crash before the preference reset logic runs.

## Issue links

- Closes #486
- Closes #450

## Test plan

- [ ] Quit the app via tray → Quit and verify process is no longer in Task Manager / `ps aux`
- [ ] Quit the app via window close (X button) and verify same
- [ ] On Linux with GPU issues: run `crossover --reset` and verify preferences reset without GPU crash
- [ ] Normal launch still works with GPU/no-GPU preferences