### PR TITLE
feat: add crosshair overlay to hero section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,7 +76,7 @@
       position:relative;min-height:100vh;min-height:100dvh;
       display:flex;flex-direction:column;
       align-items:center;justify-content:center;
-      text-align:center;padding:5rem 1.5rem 3rem;overflow:hidden;
+      text-align:center;padding:5rem 1.5rem 3rem;
     }
     @media(hover:hover){.hero{cursor:none}}
     .hero-xh,.hero-xv{position:absolute;background:var(--amber);opacity:.1;z-index:1}
@@ -362,7 +362,7 @@
       <div class="hero-demo">
         <div class="frame">
           <div class="br-bl"></div><div class="br-br"></div>
-          <img src="https://github.com/lacymorrow/crossover/raw/main/src/static/meta/demo-main.png" alt="CrossOver crosshair overlay on a game" loading="eager">
+          <img src="https://github.com/lacymorrow/crossover/raw/main/src/static/meta/demo-main.png" alt="CrossOver crosshair overlay on a game" width="628" height="338" loading="eager">
         </div>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,6 @@
       max-width:820px;width:100%;
       animation:fadeUp .8s ease 1.8s both;
     }
-    .hero-demo .frame img{border:1px solid var(--border)}
     .hero-demo .frame::before,.hero-demo .frame::after,
     .hero-demo .frame .br-bl,.hero-demo .frame .br-br{width:20px;height:20px}
 
@@ -303,6 +302,8 @@
       .fg{grid-template-columns:1fr}
       .dlg{grid-template-columns:1fr}
       .frame::before,.frame::after,.frame .br-bl,.frame .br-br{width:18px;height:18px}
+      .hero-demo .frame::before,.hero-demo .frame::after,
+      .hero-demo .frame .br-bl,.hero-demo .frame .br-br{width:18px;height:18px}
     }
     @media(max-width:480px){
       .stat{padding:1.2rem 1rem}

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,6 +152,16 @@
     .store-badge:hover{opacity:1}
     .store-badge img{height:40px;display:block}
 
+    /* HERO DEMO */
+    .hero-demo{
+      margin-top:3rem;position:relative;z-index:2;
+      max-width:820px;width:100%;
+      animation:fadeUp .8s ease 1.8s both;
+    }
+    .hero-demo .frame img{border:1px solid var(--border)}
+    .hero-demo .frame::before,.hero-demo .frame::after,
+    .hero-demo .frame .br-bl,.hero-demo .frame .br-br{width:20px;height:20px}
+
     /* MOUSE CROSSHAIR */
     .xhc{
       position:fixed;pointer-events:none;z-index:90;
@@ -347,6 +357,13 @@
         <a href="https://snapcraft.io/crossover" class="store-badge" aria-label="Get it from the Snap Store">
           <img src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" alt="Snap Store" height="40" loading="lazy">
         </a>
+      </div>
+
+      <div class="hero-demo">
+        <div class="frame">
+          <div class="br-bl"></div><div class="br-br"></div>
+          <img src="https://github.com/lacymorrow/crossover/raw/main/src/static/meta/demo-main.png" alt="CrossOver crosshair overlay on a game" loading="eager">
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- Adds the actual CrossOver product screenshot (crosshair overlay on a game) directly into the hero section
- Users immediately see what the product does without scrolling to the separate showcase section
- Styled with the existing amber corner-bracket frame treatment to match site design language
- Animates in as part of the hero entrance sequence (1.8s delay, fadeUp)

## Paperclip Issue

[LAC-1074](/LAC/issues/LAC-1074)

## Changes

- Added `.hero-demo` CSS block with `max-width: 820px`, `fadeUp` animation, and frame corner overrides (20px)
- Added `<div class="hero-demo">` inside `.hero-content` after the store badges — shows `demo-main.png` with `loading="eager"` since it's above the fold
- Showcase section below the stats remains for the full-size view

## Testing Notes

- Open `docs/index.html` in a browser (or visit crossover.lacy.sh after deploy)
- Hero should show: badge → headline → subtitle → CTA → platform note → store badges → product screenshot
- Screenshot should animate in ~1.8s after page load
- Hover over hero should still show the amber mouse-tracking crosshair cursor