### PR TITLE
fix: correct ADS resize button check and preference key

### DIFF
--- a/src/main/iohook.js
+++ b/src/main/iohook.js
@@ -470,7 +470,14 @@ const resizeOnADS = async () => {
 	}
 
 	const ads = preferences.value( 'actions.resizeOnADS' )
-	const adsSize = Number.parseInt( preferences.value( 'actions.ADSSize' ), 10 )
+
+	if ( !ads || ads === 'off' ) {
+
+		return
+
+	}
+
+	const adsSize = Number.parseInt( preferences.value( 'actions.ADSSize' ), 10 ) || 50
 	const adsToggle = ads === 'toggle'
 	const opacity = Number.parseInt( preferences.value( 'crosshair.opacity' ), 10 ) / 100
 	const oldCrosshairSize = Number.parseInt( preferences.value( 'crosshair.size' ), 10 )

--- a/src/main/iohook.js
+++ b/src/main/iohook.js
@@ -470,19 +470,22 @@ const resizeOnADS = async () => {
 	}
 
 	const ads = preferences.value( 'actions.resizeOnADS' )
-	const adsSize = Number.parseInt( preferences.value( 'actions.resizeOnADSSize' ), 10 )
-	const adsToggle = checkboxTrue( preferences.value( 'actions.resizeOnADSToggle' ), 'resizeOnADSToggle' )
+	const adsSize = Number.parseInt( preferences.value( 'actions.ADSSize' ), 10 )
+	const adsToggle = ads === 'toggle'
 	const opacity = Number.parseInt( preferences.value( 'crosshair.opacity' ), 10 ) / 100
 	const oldCrosshairSize = Number.parseInt( preferences.value( 'crosshair.size' ), 10 )
 	const newCrosshairSize = adsSize
 
 	log.info( 'Setting: ADS Resize' )
 
+	// Right mouse button (MOUSE_BUTTON2 = 2 in uiohook-napi)
+	const RIGHT_MOUSE_BUTTON = 2
+
 	if ( adsToggle ) {
 
 		const listener = event => {
 
-			if ( event.button === Number.parseInt( ads, 10 ) ) {
+			if ( event.button === RIGHT_MOUSE_BUTTON ) {
 
 				const adsed = preferences.value( 'hidden.ADSed' )
 				if ( adsed ) {
@@ -514,7 +517,7 @@ const resizeOnADS = async () => {
 
 		const mouseDownListener = event => {
 
-			if ( event.button === Number.parseInt( ads, 10 ) ) {
+			if ( event.button === RIGHT_MOUSE_BUTTON ) {
 
 				set.rendererProperties( {
 					'--crosshair-width': `${newCrosshairSize}px`,
@@ -530,7 +533,7 @@ const resizeOnADS = async () => {
 
 		const mouseUpListener = event => {
 
-			if ( event.button === Number.parseInt( ads, 10 ) ) {
+			if ( event.button === RIGHT_MOUSE_BUTTON ) {
 
 				set.rendererProperties( {
 					'--crosshair-width': `${oldCrosshairSize}px`,


### PR DESCRIPTION
## Summary

Fixes right-click resize on ADS (issue #476) — the feature was silently broken after the \`resizeOnADS\` preference was refactored from numeric button values to mode strings.

**Root cause 1 — wrong preference key:**
\`preferences.value('actions.resizeOnADSSize')\` reads a non-existent key. The actual key is \`actions.ADSSize\`. Result: \`adsSize\` was always \`NaN\`, so the crosshair would resize to 0.

**Root cause 2 — NaN button comparison:**
The preference value is now \`'toggle'\` or \`'hold'\` (strings), but the code did \`Number.parseInt(ads, 10)\` and compared the result to \`event.button\`. \`parseInt('toggle')\` and \`parseInt('hold')\` both return \`NaN\`. \`event.button === NaN\` is always \`false\`, so no resize ever triggered.

**Fix:**
- Read ADS size from the correct key: \`actions.ADSSize\`
- Derive toggle mode from \`ads === 'toggle'\` instead of a non-existent \`resizeOnADSToggle\` preference
- Use the constant \`RIGHT_MOUSE_BUTTON = 2\` (uiohook-napi \`MOUSE_BUTTON2\`) for the button check

## Test plan

- [ ] Set ADS resize to "Hold right mouse-button", set ADS size to 30, lock crosshair, right-click and verify crosshair shrinks while held and restores on release
- [ ] Set ADS resize to "Toggle right mouse-button", right-click once to shrink, right-click again to restore
- [ ] Works with built-in crosshair and with a custom GIF crosshair
- [ ] ADS resize "Never" still does nothing

Closes #476