### PR TITLE
fix: resetting bg color now also resets foreground/accent color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2026-05-16
+- fix: resetting bg color now also resets foreground/accent color ([LAC-1313](https://github.com/lacymorrow/xover/issues/3))
+
 ### 2024-12-19
 - Feature: SVG circle demo crosshair added
 - Improvements: Enhanced crosshair rendering and positioning

--- a/src/main/crossover.js
+++ b/src/main/crossover.js
@@ -347,17 +347,22 @@ const syncSettings = ( options = preferences.preferences ) => {
 		'--circle-thickness': options.crosshair.circleThickness,
 	}
 
-	// App color is set
-
-	if ( options.app.appHighlightColor.charAt( 0 ) === '#' ) {
-
-		properties['--app-highlight-color'] = options.app.appHighlightColor
-
-	}
+	// App colors — highlight only applies when bg is also set; resetting bg resets highlight too
 
 	if ( options.app.appBgColor.charAt( 0 ) === '#' ) {
 
 		properties['--app-bg-color'] = hexToRgbA( options.app.appBgColor, APP_BACKGROUND_OPACITY )
+
+		if ( options.app.appHighlightColor.charAt( 0 ) === '#' ) {
+
+			properties['--app-highlight-color'] = options.app.appHighlightColor
+
+		}
+
+	} else if ( options.app.appHighlightColor !== 'unset' ) {
+
+		// bg was reset to default — clear orphaned highlight color so buttons stay visible
+		preferences.value( 'app.appHighlightColor', 'unset' )
 
 	}
 


### PR DESCRIPTION
## Summary

- When a user resets the app background color (`appBgColor`) to its default/unset state, the foreground/accent color (`appHighlightColor`) was left intact — causing buttons to become invisible against the default background
- Fix ties the highlight color to the bg color: clearing bg also clears highlight in `syncSettings`
- Standalone highlight-color (without a custom bg) is no longer a supported state since the two are visually coupled

## Root cause

In `syncSettings` (`src/main/crossover.js`), `appHighlightColor` was applied independently of `appBgColor`. If bg was reset but highlight was still set to e.g. white, the buttons rendered as white-on-white against the system default background.

## Test plan

- [ ] Set a custom App Background Color and App Icon Color in Settings → System Settings
- [ ] Click the color reset/clear button on App Background Color
- [ ] Confirm: App Icon Color is also cleared and buttons are visible
- [ ] Confirm: Setting both colors together still works correctly
- [ ] Confirm: Theme changes (light/dark/system) still reset both colors as before

Closes #3