### PR TITLE
ci: fix Windows build script name (build:windows → build:win)

### DIFF
--- a/.github/workflows/crossover-ci.yml
+++ b/.github/workflows/crossover-ci.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build
         run: |
-          npm run build:windows
+          npm run build:win
         env:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           # We use circle as ci


### PR DESCRIPTION
## Problem

After the PR #491 actions upgrade landed, the Windows CI job now reaches the Build step but fails with:

```
npm error Missing script: "build:windows"
npm error Did you mean one of these?
npm error   npm run build:win # run the "build:win" package script
```

The `crossover-ci.yml` Windows job calls `npm run build:windows`, but the script in `package.json` is named `build:win`.

## Fix

Change `npm run build:windows` → `npm run build:win` in the Windows CI job.

## Note

Mac CI is now passing. This is the only remaining failure in `crossover-ci`.