### PR TITLE
fix: force process.exit on quit and safe GPU settings on --reset (v2)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,7 +115,7 @@ const start = async () => {
 
 	// When resetting, force safe GPU settings so the GPU process doesn't crash
 	// before the reset logic can run. (#450)
-	if ( process.env.CROSSOVER_RESET ) {
+	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
 
 		log.info( 'Reset mode: forcing safe GPU settings' )
 		app.commandLine.appendSwitch( 'disable-gpu' )
@@ -163,7 +163,7 @@ const ready = async () => {
 	log.info( 'App ready' )
 
 	// Allow command-line reset
-	if ( process.env.CROSSOVER_RESET ) {
+	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
 
 		log.info( 'Command-line reset triggered' )
 		reset.app( true )

--- a/src/main.js
+++ b/src/main.js
@@ -113,31 +113,43 @@ const start = async () => {
 	/* LINUX FIXES */
 	// More flags: https://www.electronjs.org/docs/latest/api/command-line-switches/
 
-	// Disable hardware acceleration
-	if ( checkboxTrue( preferences.value( 'app.gpu' ), 'gpu' ) ) {
+	// When resetting, force safe GPU settings so the GPU process doesn't crash
+	// before the reset logic can run. (#450)
+	if ( process.env.CROSSOVER_RESET ) {
 
-		log.info( 'Setting: Enable GPU' )
+		log.info( 'Reset mode: forcing safe GPU settings' )
+		app.commandLine.appendSwitch( 'disable-gpu' )
+		app.disableHardwareAcceleration()
 
 	} else {
 
 		// Disable hardware acceleration
-		log.info( 'Setting: Disable GPU' )
-		app.commandLine.appendSwitch( 'enable-transparent-visuals' )
-		app.commandLine.appendSwitch( 'disable-gpu' )
-		app.disableHardwareAcceleration()
+		if ( checkboxTrue( preferences.value( 'app.gpu' ), 'gpu' ) ) {
 
-	}
+			log.info( 'Setting: Enable GPU' )
 
-	// Fix for Linux transparency issues: wayland on linux/sway
-	// This switch runs the GPU process in the same process as the browser, which can help avoid the issues with transparency.
-	// https://github.com/microsoft/vscode/issues/146464
-	// https://www.electronjs.org/docs/latest/api/command-line-switches/#in-process-gpu
-	if ( !checkboxTrue( preferences.value( 'app.gpuprocess' ), 'gpuprocess' ) ) {
+		} else {
 
-		log.info( 'Setting: Sharing GPU process and browser' )
+			// Disable hardware acceleration
+			log.info( 'Setting: Disable GPU' )
+			app.commandLine.appendSwitch( 'enable-transparent-visuals' )
+			app.commandLine.appendSwitch( 'disable-gpu' )
+			app.disableHardwareAcceleration()
 
-		app.commandLine.appendSwitch( 'in-process-gpu' )
-		app.commandLine.appendSwitch( 'use-gl=desktop' )
+		}
+
+		// Fix for Linux transparency issues: wayland on linux/sway
+		// This switch runs the GPU process in the same process as the browser, which can help avoid the issues with transparency.
+		// https://github.com/microsoft/vscode/issues/146464
+		// https://www.electronjs.org/docs/latest/api/command-line-switches/#in-process-gpu
+		if ( !checkboxTrue( preferences.value( 'app.gpuprocess' ), 'gpuprocess' ) ) {
+
+			log.info( 'Setting: Sharing GPU process and browser' )
+
+			app.commandLine.appendSwitch( 'in-process-gpu' )
+			app.commandLine.appendSwitch( 'use-gl=desktop' )
+
+		}
 
 	}
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -102,9 +102,16 @@ const appEvents = () => {
 	app.on( 'will-quit', () => {
 
 		// IOHook already stopped in before-quit; just clean up keyboard shortcuts
-		// then force-exit to prevent lingering handles from keeping the process alive.
-		keyboard.unregisterShortcuts()
-		process.exit( EXIT_CODES.SUCCESS )
+		// then force-exit to prevent lingering handles from keeping the process alive. (#486)
+		try {
+
+			keyboard.unregisterShortcuts()
+
+		} finally {
+
+			app.exit( EXIT_CODES.SUCCESS )
+
+		}
 
 	} )
 

--- a/src/main/register.js
+++ b/src/main/register.js
@@ -7,6 +7,7 @@ const keyboard = require( './keyboard' )
 const log = require( './log' )
 const reset = require( './reset' )
 const windows = require( './windows' )
+const EXIT_CODES = require( '../config/exit-codes' )
 
 const appEvents = () => {
 
@@ -101,8 +102,9 @@ const appEvents = () => {
 	app.on( 'will-quit', () => {
 
 		// IOHook already stopped in before-quit; just clean up keyboard shortcuts
+		// then force-exit to prevent lingering handles from keeping the process alive.
 		keyboard.unregisterShortcuts()
-		// process.exit( EXIT_CODES.SUCCESS )
+		process.exit( EXIT_CODES.SUCCESS )
 
 	} )
 


### PR DESCRIPTION
Replaces #494 with conflict-resolved version rebased on current main.

## Changes

- Force-quits via `app.exit()` in `will-quit` with try/finally so keyboard cleanup errors don't prevent exit
- Skips GPU sandbox on `--reset` flag to avoid GPU process crash during reset flow
- IOHook already stopped in `before-quit`; `will-quit` only cleans up keyboard shortcuts then force-exits

## Notes

- Conflict resolved: `before-quit` stops IOHook (from #492), `will-quit` only unregisters shortcuts
- Uses `app.exit()` per Gemini review (avoids Node.js `process.exit` in Electron)

Closes #494