### PR TITLE
ci: upgrade upload-artifact v4 → v6 (Node.js 20 deprecation fix)

### DIFF
--- a/.github/workflows/crossover-ci.yml
+++ b/.github/workflows/crossover-ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload Test Results 🗃
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/*


### PR DESCRIPTION
`actions/upload-artifact@v4` runs on Node.js 20 which GitHub is deprecating. Starting June 2nd, 2026, Node.js 20 actions will be forced to run with Node.js 24, which may break them.

Upgrades the Mac job artifact upload to `actions/upload-artifact@v6` (Node.js 24 compatible, released December 2025).