### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/crossover-ci.yml
+++ b/.github/workflows/crossover-ci.yml
@@ -17,7 +17,7 @@ jobs:
           rm -rf *
         if: ${{ always() }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Check memory and cpu
       - name: Verify Runner Resources
@@ -31,7 +31,7 @@ jobs:
         id: get-node-version
 
       - name: Use Node.js ${{ steps.get-node-version.outputs.nodeversion }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.get-node-version.outputs.nodeversion }}
 
@@ -90,7 +90,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get Node Version
         run: |
@@ -102,7 +102,7 @@ jobs:
         id: get-node-version
 
       - name: Use Node.js ${{ steps.get-node-version.outputs.nodeversion }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.get-node-version.outputs.nodeversion }}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       
       - name: Get Node Version
         run: |
@@ -28,7 +28,7 @@ jobs:
         id: get-node-version
       
       - name: Use Node.js ${{ steps.get-node-version.outputs.nodeversion }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.get-node-version.outputs.nodeversion }}
           cache: "npm"


### PR DESCRIPTION
## Summary

GitHub Actions will force Node.js 24 by default starting **June 2nd, 2026**. This upgrades workflows to use Node.js 24-compatible action versions before the deadline.

Changes:
- `actions/checkout` @v3/@v4 → `@v6`
- `actions/setup-node` @v3/@v4 → `@v6`
- `github/codeql-action` @v2/@v3 → `@v4`
- `dependabot/fetch-metadata` @v1 → `@v3`

## Test plan

- [ ] CI/CodeQL workflows pass after merge