### PR TITLE
ci: add release workflow for automated cross-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and publish macOS
+        run: npx electron-builder --macos --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and publish Windows
+        run: npx electron-builder --win --ia32 --x64 --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      - name: Build and publish Linux
+        run: npx electron-builder --linux AppImage deb --x64 --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-snap:
+    runs-on: ubuntu-latest
+    needs: release-linux
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+
+      - name: Build and publish snap
+        run: npx electron-builder --linux snap --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on version tags (`v*`)
- Builds macOS (universal DMG), Windows (NSIS + Portable, ia32/x64), Linux (AppImage + deb), and snap on native runners
- Uses `electron-builder --publish always` to upload artifacts directly to the draft GitHub release

## How it works
1. Run `npm run release` locally → `np` bumps version, creates tag, pushes, opens draft release with changelog
2. Tag push triggers this workflow → builds all platforms in parallel
3. `electron-builder` uploads artifacts to the existing draft release
4. Review the draft and publish when ready

## Notes
- Snap Store publishing requires `SNAPCRAFT_STORE_CREDENTIALS` secret (optional — snap still uploads to GitHub release without it)
- No code signing configured yet — macOS users will see Gatekeeper warning (same as current behavior)
- Replaces the need for AppVeyor/CircleCI for release builds (they remain useful as CI checks)

## Test plan
- [ ] Merge to main
- [ ] Run `npm run release` to create a test version tag
- [ ] Verify all three platform jobs trigger and complete
- [ ] Verify artifacts appear on the draft GitHub release