### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "version": "3.4.2",
   "description": "A Crosshair Overlay for any screen",
   "copyright": "Copyright © Lacy Morrow",
-  "repository": "lacymorrow/crossover",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lacymorrow/crossover.git"
+  },
   "homepage": "https://lacymorrow.github.io/crossover",
   "company": "Fly5",
   "author": {


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`
- Normalize URLs to `git+https://` format

Automated fix via `npm pkg fix`. Addresses npm publish warnings.