### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/renderer/chooser.html
+++ b/src/renderer/chooser.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>Crosshairs</title>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval';">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https:; object-src 'self';">
 		<link rel="stylesheet" href="styles/dist/index.css">
 		<script type="text/javascript" src="vendor/feather/feather-icons.min.js"></script>
 	</head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 		<title>CrossOver</title>
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; media-src *;">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; media-src *;">
 		<link rel="stylesheet" href="styles/dist/index.css">
 		<script type="text/javascript" src="vendor/feather/feather-icons.min.js"></script>
 		<script type="text/javascript" src="vendor/inline-svg/inline-svg.min.js"></script>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src/renderer/chooser.html:L6`

The chooser.html file uses a very permissive Content-Security-Policy that allows 'unsafe-inline' for scripts and styles, and 'unsafe-eval' for scripts. This significantly weakens the security benefits of CSP and could allow XSS attacks if any user-controlled data reaches the renderer.

## Solution

Remove 'unsafe-inline' and 'unsafe-eval' from the CSP. Use nonce or hash-based CSP for inline scripts. If 'unsafe-eval' is needed for a specific library, consider using a safer alternative or sandboxing that code.

## Changes

- `src/renderer/chooser.html` (modified)
- `src/renderer/index.html` (modified)