### PR TITLE
fix: add missing TROUBLESHOOTING_URL and COMPATIBILITY_URL constants

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -10,6 +10,8 @@ const DEFAULT_DEBOUNCE = 20
 const DEFAULT_THEME = 'light'
 const ALERT_URL = 'https://raw.githubusercontent.com/lacymorrow/crossover/master/CROSSOVER_ALERT'
 const HOMEPAGE_URL = 'https://lacymorrow.github.io/crossover'
+const TROUBLESHOOTING_URL = 'https://github.com/lacymorrow/crossover#game-compatibility'
+const COMPATIBILITY_URL = 'https://github.com/lacymorrow/crossover/issues/47'
 const RELEASES_URL = 'https://github.com/lacymorrow/crossover/releases/latest'
 const APP_ASPECT_RATIO = 16 / 10
 const APP_HEIGHT_MEDIUM = 225
@@ -43,8 +45,10 @@ const config = {
 	DEFAULT_THEME,
 	FILE_FILTERS,
 	ALERT_URL,
+	COMPATIBILITY_URL,
 	HOMEPAGE_URL,
 	RELEASES_URL,
+	TROUBLESHOOTING_URL,
 	MAX_SHADOW_WINDOWS,
 	SETTINGS_WINDOW_DEVTOOLS,
 	SHADOW_WINDOW_OFFSET,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,58 @@
+const fs = require( 'fs' )
+const path = require( 'path' )
+const { expect, test } = require( '@playwright/test' )
+const config = require( '../src/config/config.js' )
+
+const SRC_DIR = path.resolve( 'src' )
+
+const collectSourceFiles = dir => fs.readdirSync( dir, { withFileTypes: true } )
+	.flatMap( entry => {
+
+		const fullPath = path.join( dir, entry.name )
+		if ( entry.isDirectory() ) {
+
+			return collectSourceFiles( fullPath )
+
+		}
+
+		return entry.name.endsWith( '.js' ) ? [ fullPath ] : []
+
+	} )
+
+// Regression test for #529: menu.js destructured TROUBLESHOOTING_URL and
+// COMPATIBILITY_URL from config.js before they existed, crashing the main
+// process on startup. Every key destructured from config must be exported.
+test( 'All constants destructured from config are exported', async () => {
+
+	const requirePattern = /const\s*{([^}]+)}\s*=\s*require\(\s*'[./]+config\/config'\s*\)/g
+
+	for ( const file of collectSourceFiles( SRC_DIR ) ) {
+
+		const source = fs.readFileSync( file, 'utf8' )
+		for ( const match of source.matchAll( requirePattern ) ) {
+
+			const keys = match[1].split( ',' ).map( key => key.trim() ).filter( Boolean )
+			for ( const key of keys ) {
+
+				expect( config[key], `${key} destructured in ${path.relative( SRC_DIR, file )} must be exported from config.js` ).toBeDefined()
+
+			}
+
+		}
+
+	}
+
+} )
+
+test( 'Exported URL constants are valid URLs', async () => {
+
+	const urlKeys = Object.keys( config ).filter( key => key.endsWith( '_URL' ) )
+	expect( urlKeys.length ).toBeGreaterThan( 0 )
+
+	for ( const key of urlKeys ) {
+
+		expect( () => new URL( config[key] ), `${key} must be a parseable URL` ).not.toThrow()
+
+	}
+
+} )


### PR DESCRIPTION
Fixes the v3.4.4 startup crash on all platforms (#529): `menu.js` destructures `TROUBLESHOOTING_URL` and `COMPATIBILITY_URL` from `src/config/config.js`, but they were never defined there. `openUrlMenuItem` throws \`The \`url\` option is required\` at module load, crashing the main process before any window opens.

## Changes
- Add `TROUBLESHOOTING_URL` and `COMPATIBILITY_URL` constants to `src/config/config.js` and export them.
- Regression test (`test/config.spec.js`): every key destructured from `config/config` anywhere in `src/` must exist in config's exports, and all exported `*_URL` values must parse as URLs. The test fails on the pre-fix tree and passes with the fix.

## Testing
- `playwright test test/config.spec.js` — 2 passed with fix; verified the first test fails when `config.js` is reverted to the v3.4.4 version.
- `eslint` clean on the new test file.

Paperclip: LAC-3424

🤖 Generated with [Claude Code](https://claude.com/claude-code)