### PR TITLE
fix: surface notification when globalShortcut.register() fails

### DIFF
--- a/src/main/crossover.js
+++ b/src/main/crossover.js
@@ -232,8 +232,8 @@ const registerKeyboardShortcuts = () => {
 
 		log.warn( `Shortcut registration failed for: ${failed.join( ', ' )}` )
 
-		// Notify the user — renderer must be ready; guard against early startup calls
-		try {
+		// Notify the user — only if the renderer window is ready
+		if ( windows.win && !windows.win.isDestroyed() ) {
 
 			const notification = require( './notification' )
 			notification( {
@@ -241,9 +241,6 @@ const registerKeyboardShortcuts = () => {
 				body: `Could not register: ${failed.join( ', ' )}. Another app may be using this combo. Try rebinding in Settings.`,
 			} )
 
-		} catch ( _err ) {
-
-			// Window not yet ready — failure already logged above
 		}
 
 	}

--- a/src/main/crossover.js
+++ b/src/main/crossover.js
@@ -185,7 +185,12 @@ const registerKeyboardShortcuts = () => {
 	// Register all shortcuts
 	const { keybinds } = Preferences.getDefaults()
 	const custom = preferences.value( 'keybinds' ) // Defaults
+	const failed = []
+
 	for ( const shortcut of keyboardShortcuts() ) {
+
+		let accelerator
+		let registered
 
 		// Custom shortcuts
 		if ( custom[shortcut.action] === '' ) {
@@ -196,20 +201,49 @@ const registerKeyboardShortcuts = () => {
 
 			// If a custom shortcut exists for this action
 			log.info( `Custom keybind for ${shortcut.action}` )
-			keyboard.registerShortcut( custom[shortcut.action], shortcut.fn )
+			accelerator = custom[shortcut.action]
+			registered = keyboard.registerShortcut( accelerator, shortcut.fn )
 
 		} else if ( keybinds[shortcut.action] ) {
 
 			// Set default keybind
-			keyboard.registerShortcut( keybinds[shortcut.action], shortcut.fn )
+			accelerator = keybinds[shortcut.action]
+			registered = keyboard.registerShortcut( accelerator, shortcut.fn )
 
 		} else {
 
 			// Fallback to internal bind - THIS SHOULDNT HAPPEN
 			// if it does you forgot to add a default keybind for this shortcut
 			log.info( 'ERROR - you likely forgot to add a default keybind for this shortcut: ', shortcut )
-			keyboard.registerShortcut( shortcut.keybind, shortcut.fn )
+			accelerator = shortcut.keybind
+			registered = keyboard.registerShortcut( accelerator, shortcut.fn )
 
+		}
+
+		if ( accelerator && registered === false ) {
+
+			failed.push( accelerator )
+
+		}
+
+	}
+
+	if ( failed.length > 0 ) {
+
+		log.warn( `Shortcut registration failed for: ${failed.join( ', ' )}` )
+
+		// Notify the user — renderer must be ready; guard against early startup calls
+		try {
+
+			const notification = require( './notification' )
+			notification( {
+				title: 'Keyboard Shortcut Conflict',
+				body: `Could not register: ${failed.join( ', ' )}. Another app may be using this combo. Try rebinding in Settings.`,
+			} )
+
+		} catch ( _err ) {
+
+			// Window not yet ready — failure already logged above
 		}
 
 	}

--- a/src/main/keyboard.js
+++ b/src/main/keyboard.js
@@ -22,7 +22,19 @@ const registerEscape = ( action = keyboard.escapeAction ) => {
 
 }
 
-const registerShortcut = ( ...args ) => globalShortcut.register( ...args )
+const registerShortcut = ( accelerator, fn ) => {
+
+	const registered = globalShortcut.register( accelerator, fn )
+	if ( !registered ) {
+
+		// eslint-disable-next-line no-console
+		console.warn( `[CrossOver] globalShortcut.register failed for: ${accelerator} (another app may have claimed this combo)` )
+
+	}
+
+	return registered
+
+}
 
 const unregisterShortcut = ( ...args ) => globalShortcut.unregister( ...args )
 

--- a/src/main/keyboard.js
+++ b/src/main/keyboard.js
@@ -1,4 +1,5 @@
 const { globalShortcut } = require( 'electron' )
+const log = require( './log' )
 const windows = require( './windows' )
 
 const escapeAction = () => {
@@ -27,8 +28,7 @@ const registerShortcut = ( accelerator, fn ) => {
 	const registered = globalShortcut.register( accelerator, fn )
 	if ( !registered ) {
 
-		// eslint-disable-next-line no-console
-		console.warn( `[CrossOver] globalShortcut.register failed for: ${accelerator} (another app may have claimed this combo)` )
+		log.warn( `globalShortcut.register failed for: ${accelerator} (another app may have claimed this combo)` )
 
 	}
 


### PR DESCRIPTION
## Problem

CrossOver uses Electron's `globalShortcut.register()` to bind keyboard shortcuts. This function returns `false` when registration fails silently — which happens on Windows when the OS, a game, or an overlay (Discord, GeForce Experience, Xbox Game Bar) has already claimed the key combo. CrossOver ignored the return value, leaving the shortcut inactive with no feedback to the user.

This explains the pattern in #516: shortcut works after rebinding (because `unregisterAll()` + re-register runs while no conflict exists), then breaks on next launch (registration fails at startup when the conflict is already present).

## Changes

**`src/main/keyboard.js`**
- `registerShortcut()` now returns the boolean from `globalShortcut.register()` and logs a `console.warn` when it returns `false`

**`src/main/crossover.js`**
- `registerKeyboardShortcuts()` collects all failed accelerators and fires a user-facing notification listing the conflicting combos
- Notification is wrapped in try/catch so early startup calls (before the renderer is ready) degrade gracefully to log-only

## Test plan

- [ ] Launch CrossOver with no conflicts — shortcuts work normally, no notification shown
- [ ] Simulate a conflict: register a matching combo in another app, then launch CrossOver — notification appears naming the failed shortcut
- [ ] Rebind the shortcut to an unused combo — notification clears on next sync
- [ ] Verify early startup path does not throw (notification silently suppressed before renderer loads)

Closes #516