### PR TITLE
fix(portable): keep userData next to the exe in portable builds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,6 +58,12 @@ console.time( 'init' )
 const process = require( 'process' )
 
 const { app } = require( 'electron' )
+
+// Portable-mode path override MUST run before any module that reads
+// app.getPath('userData') (electron-log, electron-preferences, etc.).
+const { initPortablePaths } = require( './main/portable.js' )
+const isPortable = initPortablePaths()
+
 const debug = require( 'electron-debug' )
 const { checkboxTrue } = require( './config/utils.js' )
 
@@ -82,6 +88,12 @@ const start = async () => {
 	/* App setup */
 	console.log( '***************' )
 	log.info( `CrossOver ${app.getVersion()} ${is.development ? '* Development *' : ''}` )
+
+	if ( isPortable ) {
+
+		log.info( `Portable mode: userData redirected to ${app.getPath( 'userData' )}` )
+
+	}
 
 	// Enable sandbox globally
 	// app.enableSandbox()

--- a/src/main/portable.js
+++ b/src/main/portable.js
@@ -1,0 +1,28 @@
+const path = require( 'path' )
+const { app } = require( 'electron' )
+
+// When electron-builder's portable target launches the exe, it sets
+// PORTABLE_EXECUTABLE_DIR to the directory containing the .exe. Redirect
+// userData, logs, and crash dumps into a `data/` folder alongside the exe
+// so the portable build actually keeps its state in that folder instead
+// of %APPDATA%\CrossOver.
+// See: https://www.electron.build/configuration/nsis#portable
+const initPortablePaths = () => {
+
+	const portableDir = process.env.PORTABLE_EXECUTABLE_DIR
+	if ( !portableDir ) {
+
+		return false
+
+	}
+
+	const dataDir = path.join( portableDir, 'data' )
+	app.setPath( 'userData', dataDir )
+	app.setPath( 'logs', path.join( dataDir, 'logs' ) )
+	app.setPath( 'crashDumps', path.join( dataDir, 'crashDumps' ) )
+
+	return true
+
+}
+
+module.exports = { initPortablePaths }

--- a/src/main/portable.js
+++ b/src/main/portable.js
@@ -1,3 +1,4 @@
+const fs = require( 'fs' )
 const path = require( 'path' )
 const { app } = require( 'electron' )
 
@@ -17,9 +18,26 @@ const initPortablePaths = () => {
 	}
 
 	const dataDir = path.join( portableDir, 'data' )
-	app.setPath( 'userData', dataDir )
-	app.setPath( 'logs', path.join( dataDir, 'logs' ) )
-	app.setPath( 'crashDumps', path.join( dataDir, 'crashDumps' ) )
+	const logsDir = path.join( dataDir, 'logs' )
+	const crashDir = path.join( dataDir, 'crashDumps' )
+
+	try {
+
+		fs.mkdirSync( logsDir, { recursive: true } )
+		fs.mkdirSync( crashDir, { recursive: true } )
+		app.setPath( 'userData', dataDir )
+		app.setPath( 'logs', logsDir )
+		app.setPath( 'crashDumps', crashDir )
+
+	} catch ( error ) {
+
+		// If the portable directory isn't writable (e.g. read-only media),
+		// fall back to the default %APPDATA% paths rather than crashing.
+		console.error( '[portable] failed to init portable paths, falling back to defaults:', error )
+
+		return false
+
+	}
 
 	return true
 


### PR DESCRIPTION
## Summary

Closes #379. Paperclip: [LAC-1633](https://paperclip.ing/LAC/issues/LAC-1633).

The portable Windows build was still writing its config to `%APPDATA%\CrossOver` because Electron's `userData` path defaults there and nothing overrode it.

electron-builder's portable target sets `PORTABLE_EXECUTABLE_DIR` to the directory containing the running `.exe`. We now detect that at startup and redirect `userData`, `logs`, and `crashDumps` into a `data/` folder next to the exe — so dropping `CrossOver-Portable-x.y.z.exe` in any folder keeps all state right there. No behavior change for the installer build.

- New: `src/main/portable.js` — reads `PORTABLE_EXECUTABLE_DIR` and calls `app.setPath(...)` for `userData`, `logs`, `crashDumps`.
- Wired in `src/main.js` **before** `electron-log`/`electron-preferences`/error-handling are required (they cache the path on load).
- Logs a one-line notice when portable mode is active so users can confirm from the log file.

## Test plan

- [x] Sanity script with `PORTABLE_EXECUTABLE_DIR=/tmp/xtest` → all three paths resolve under `/tmp/xtest/data`.
- [x] Same script without the env var → `userData` unchanged (default electron path).
- [x] `eslint src/main/portable.js src/main.js` clean.
- [ ] Windows portable smoke: build via `electron-builder --win portable`, run the exe from a non-standard path (e.g. `D:\UserPrograms\CrossOver\`), confirm `data/preferences.json` appears next to the exe and nothing shows up in `%APPDATA%\CrossOver`.