### PR TITLE
feat(overlay): add "Hide from screen recording" preference

### DIFF
--- a/src/main/crossover.js
+++ b/src/main/crossover.js
@@ -409,6 +409,9 @@ const syncSettings = ( options = preferences.preferences ) => {
 
 	} )
 
+	// Sync screen-capture exclusion across all windows (#359)
+	windows.syncContentProtection()
+
 	set.startOnBoot()
 
 	// Reset all custom shortcuts

--- a/src/main/preferences.js
+++ b/src/main/preferences.js
@@ -55,6 +55,7 @@ const getDefaults = () => ( {
 		updates: [ 'updates' ],
 		sounds: [ 'sounds' ],
 		gpu: [ 'gpu' ],
+		hideFromScreenCapture: [],
 		startUnlocked: [ 'startUnlocked' ],
 		boot: [],
 		appSize: 'normal',
@@ -570,6 +571,13 @@ const preferencesConfig = {
 								type: 'checkbox',
 								options: [ { label: 'This switch runs the GPU process in the same process as the browser', value: 'gpuprocess' } ],
 								help: 'This can help avoid issues with transparency.',
+							},
+							{
+								label: 'Hide From Screen Recording',
+								key: 'hideFromScreenCapture',
+								type: 'checkbox',
+								options: [ { label: 'Exclude the crosshair from screen captures and recordings', value: 'hideFromScreenCapture' } ],
+								help: 'Prevents the crosshair from showing up in screen recordings (e.g. GeForce Instant Replay, OBS, screenshots). The crosshair remains visible on-screen. Requires Windows 10 or later for full effect.',
 							},
 							{
 								label: 'Run App On System Start',

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -4,6 +4,7 @@ const { app, BrowserWindow, screen } = require( 'electron' )
 
 const { activeWindow, centerWindow, is } = require( './util' )
 const { APP_HEIGHT, APP_WIDTH, MAX_SHADOW_WINDOWS, APP_ASPECT_RATIO } = require( '../config/config.js' )
+const { checkboxTrue } = require( '../config/utils.js' )
 const { productName } = require( '../../package.json' )
 const dock = require( './dock.js' )
 const log = require( './log.js' )
@@ -77,6 +78,43 @@ const getActiveWindow = () => {
 
 }
 
+// Toggle whether a window is excluded from screen captures / recordings (#359)
+// Uses Electron's setContentProtection, which maps to WDA_MONITOR / WDA_EXCLUDEFROMCAPTURE
+// on Windows and NSWindowSharingNone on macOS.
+const applyContentProtection = ( win, enabled = checkboxTrue( preferences.value( 'app.hideFromScreenCapture' ), 'hideFromScreenCapture' ) ) => {
+
+	if ( !win || win.isDestroyed() ) {
+
+		return
+
+	}
+
+	try {
+
+		win.setContentProtection( Boolean( enabled ) )
+
+	} catch ( error ) {
+
+		log.error( `setContentProtection failed: ${error?.message}` )
+
+	}
+
+}
+
+// Apply the current hideFromScreenCapture preference to every crosshair window
+const syncContentProtection = () => {
+
+	const enabled = checkboxTrue( preferences.value( 'app.hideFromScreenCapture' ), 'hideFromScreenCapture' )
+	applyContentProtection( windows.win, enabled )
+
+	for ( const currentWindow of windows.shadowWindows ) {
+
+		applyContentProtection( currentWindow, enabled )
+
+	}
+
+}
+
 // Prevent window from being garbage collected
 // Default no shadow window
 const create = ( { isShadowWindow } = { isShadowWindow: false } ) => {
@@ -140,6 +178,9 @@ const create = ( { isShadowWindow } = { isShadowWindow: false } ) => {
 	// Values include normal, floating, torn-off-menu, modal-panel, main-menu, status, pop-up-menu, screen-saver
 	win.setAlwaysOnTop( true, 'screen-saver', 1 )
 	win.setFullScreenable( false )
+
+	// Exclude the crosshair from screen recordings / captures when enabled (#359)
+	applyContentProtection( win )
 
 	win.once( 'ready-to-show', () => {
 
@@ -594,6 +635,8 @@ const unregister = () => {
 
 const windows = {
 
+	applyContentProtection,
+	syncContentProtection,
 	init,
 	load,
 	each,


### PR DESCRIPTION
Closes #359

## Summary

Adds an app preference **Hide From Screen Recording** that excludes the crosshair windows (main + all shadows) from screen captures — GeForce Instant Replay, OBS, screenshots, etc. The crosshair remains visible to the player; the recording just doesn't see it, which matches how Crosshair v2 behaves per the issue reporter.

Implemented via Electron's [`BrowserWindow.setContentProtection`](https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable), which maps to `SetWindowDisplayAffinity` on Windows and `NSWindowSharingNone` on macOS.

## Changes

- New default `app.hideFromScreenCapture` (off by default) in `src/main/preferences.js`
- New checkbox in the App settings section
- `windows.applyContentProtection(win)` runs on window create for main + shadow windows
- `windows.syncContentProtection()` is called from `crossover.syncSettings()` so toggling the preference takes effect immediately, no restart required
- Errors from `setContentProtection` are caught + logged (defensive; older platforms)

Paperclip issue: [LAC-1634](https://paperclip.ing/LAC/issues/LAC-1634)

## Test plan

- [ ] Enable "Hide From Screen Recording" in Preferences → App
- [ ] Verify crosshair is still visible on-screen
- [ ] Start GeForce Instant Replay / OBS / Windows Game Bar recording; save/preview and confirm the crosshair does **not** appear in the recording
- [ ] Take a screenshot (Snipping Tool / Print Screen); confirm the crosshair does not appear
- [ ] Disable the preference; confirm the crosshair reappears in recordings without restarting the app
- [ ] Duplicate the crosshair with `Ctrl+Shift+Alt+D` and confirm shadow windows inherit the setting