### PR TITLE
docs: clarify which macOS download to grab (fixes #335)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,17 @@ Or get it from the [Microsoft Store](https://apps.microsoft.com/detail/9mtd5zln7
 
 ### macOS
 
-Download the `.dmg` for your architecture (Intel `x64` or Apple Silicon `arm64`) from the [releases page](https://github.com/lacymorrow/crossover/releases/latest).
+Grab a `.dmg` from the [releases page](https://github.com/lacymorrow/crossover/releases/latest), open it, and drag **CrossOver** into your **Applications** folder.
+
+**Which file?** Pick one — any of these will work:
+
+| File | Use if |
+|------|--------|
+| `CrossOver-<version>-universal.dmg` | You're not sure — this one runs on any Mac (Intel or Apple Silicon). |
+| `CrossOver-<version>-arm64.dmg` | You have an Apple Silicon Mac (M1/M2/M3/M4). Smaller download. |
+| `CrossOver-<version>-x64.dmg` | You have an Intel Mac. |
+
+To check which Mac you have: **Apple menu ▸ About This Mac** — look for **Chip** (Apple Silicon, e.g. *Apple M1*) or **Processor** (Intel). The `.zip` files contain the same app as the matching `.dmg` if you prefer that format.
 
 If macOS says *"CrossOver cannot be opened because the developer cannot be verified"*: locate the app, **Control-click** it, then choose **Open**.
 


### PR DESCRIPTION
## Summary

Users on macOS regularly ask which file to download from the releases page — the previous README section just said "pick the dmg for your architecture" without telling them how to figure out their architecture or that a `universal.dmg` exists.

This PR expands the macOS section of the README with:

- A small table mapping each `.dmg` variant to when to use it (`universal.dmg` as the safe default, `arm64.dmg` for Apple Silicon, `x64.dmg` for Intel)
- Guidance on how to check the chip (**Apple menu ▸ About This Mac**)
- A note that the `.zip` files are the same app in a different container

Fixes lacymorrow/crossover#335.
Paperclip: [LAC-1638](https://paperclip.ing/LAC/issues/LAC-1638)

## Test plan

- [x] README renders correctly on GitHub (markdown table preview)
- [ ] Reviewer confirms wording matches how they'd answer the question in Discussions