### PR TITLE
fix(linux): argv fallback for --reset + expand Linux docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,11 +114,47 @@ $ sudo snap install crossover
 
 `AppImage` needs to be [made executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80) after download. Some lightweight desktop environments require a compositor for the overlay to work ([#230](https://github.com/lacymorrow/crossover/issues/230)).
 
-Advanced features (lock, hide, ADS resize, mouse follow) rely on `libxkbcommon`:
+Advanced features (lock, hide, ADS resize, mouse follow) rely on `libxkbcommon` and a few X11 helper libs:
 
 ```sh
-$ sudo apt install libxkbcommon-x11-0      # Ubuntu / Pop!_OS
-$ sudo dnf install libxkbcommon-x11        # Fedora
+# Ubuntu / Pop!_OS / Linux Mint
+$ sudo apt install libxkbcommon-x11-0 libxtst6 libnotify4 libnss3 libsecret-1-0
+
+# Fedora / Nobara
+$ sudo dnf install libxkbcommon-x11 libXtst libnotify nss libsecret
+
+# Arch
+$ sudo pacman -S libxkbcommon-x11 libxtst libnotify nss libsecret
+```
+
+#### X11 vs Wayland
+
+CrossOver's transparent overlay currently works best on **X11**. If you're on Wayland (default on GNOME 40+, KDE Plasma 6, and most modern distros) and see a black or opaque background:
+
+- Log out and pick **"GNOME on Xorg"** or **"Plasma (X11)"** at the login screen.
+- Or launch with the Wayland-to-X11 shim: `crossover --ozone-platform=x11`.
+- KDE/KWin on Wayland is the most affected combination ([#450](https://github.com/lacymorrow/crossover/issues/450)).
+
+#### Linux Mint 22 Cinnamon
+
+Cinnamon disables compositing on certain themes, which hides the overlay. Enable compositing in **System Settings → General → Enable compositing** and restart CrossOver ([#468](https://github.com/lacymorrow/crossover/issues/468)).
+
+#### Nobara / gaming distros
+
+Overlays don't draw on top of Proton/Vulkan games — the crosshair renders on the desktop but not over the game window. Use windowed or borderless mode and see [Vulkan-based games](#game-compatibility) above ([#347](https://github.com/lacymorrow/crossover/issues/347)).
+
+#### Fedora Silverblue / immutable distros
+
+If CrossOver core-dumps on start, GPU sandboxing is likely blocked. Launch with `crossover --disable-gpu-sandbox` or install the Flatpak build once available ([#120](https://github.com/lacymorrow/crossover/issues/120)).
+
+#### Reset stuck preferences
+
+If the app crashes on launch after a bad setting, wipe preferences:
+
+```sh
+$ crossover --reset          # preferred — clears prefs and restarts
+$ crossover --disable-gpu --reset   # if the GPU process crashes before reset runs
+$ rm -rf ~/.config/CrossOver    # nuclear option — delete the config dir directly
 ```
 
 ## Usage

--- a/src/main.js
+++ b/src/main.js
@@ -74,6 +74,17 @@ const reset = require( './main/reset.js' )
 const tray = require( './main/tray.js' )
 const { appId } = require( '../package.json' )
 
+// Detect `--reset` from env, Electron switch, or raw argv.
+// Some Linux launchers (AppImage/Snap/Flatpak) can strip Chromium switches, so
+// fall back to scanning argv for `--reset` / `-reset` / `reset`.
+const isResetRequested = () => {
+
+	if ( process.env.CROSSOVER_RESET ) return true
+	if ( app.commandLine.hasSwitch( 'reset' ) ) return true
+	return process.argv.slice( 1 ).some( arg => arg === '--reset' || arg === '-reset' || arg === 'reset' )
+
+}
+
 const start = async () => {
 
 	// Handle errors early
@@ -115,7 +126,9 @@ const start = async () => {
 
 	// When resetting, force safe GPU settings so the GPU process doesn't crash
 	// before the reset logic can run. (#450)
-	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
+	// Also match on process.argv — AppImage/Snap/Flatpak launchers occasionally
+	// strip Chromium switches, so hasSwitch() alone can miss `--reset` on Linux.
+	if ( isResetRequested() ) {
 
 		log.info( 'Reset mode: forcing safe GPU settings' )
 		app.commandLine.appendSwitch( 'disable-gpu' )
@@ -163,7 +176,7 @@ const ready = async () => {
 	log.info( 'App ready' )
 
 	// Allow command-line reset
-	if ( process.env.CROSSOVER_RESET || app.commandLine.hasSwitch( 'reset' ) ) {
+	if ( isResetRequested() ) {
 
 		log.info( 'Command-line reset triggered' )
 		reset.app( true )


### PR DESCRIPTION
Paperclip: [LAC-2663](https://paperclip.ing/LAC/issues/LAC-2663)

Closes #450 · Refs #468, #347, #120

## Changes

### `src/main.js` — argv fallback for `--reset`

`app.commandLine.hasSwitch('reset')` covers the happy path, but some Linux launchers (AppImage / Snap / Flatpak wrappers) strip Chromium switches before Electron sees them. Added a `process.argv` scan that also matches `--reset`, `-reset`, and bare `reset`. Env var (`CROSSOVER_RESET=1`) still works as before.

Extracted into `isResetRequested()` so the two call sites (`start` for GPU-safe boot, `ready` for the actual reset trigger) stay in sync.

### `readme.md` — Linux section

Consolidated the Linux troubleshooting content around the specific reports in this cluster:

- Distro-specific dep lists: added `libXtst`, `libnotify`, `nss`, `libsecret` alongside the existing `libxkbcommon` line — for Ubuntu/Mint, Fedora/Nobara, and Arch.
- **X11 vs Wayland** subsection — how to switch sessions, or use `--ozone-platform=x11` as a shim.
- **Linux Mint 22 Cinnamon** — enable compositing (#468).
- **Nobara / gaming distros** — Proton/Vulkan overlays don't draw over the game window (#347); cross-links to the game compatibility table.
- **Fedora Silverblue** — `--disable-gpu-sandbox` workaround (#120).
- **Reset recovery** — `--reset`, `--disable-gpu --reset`, and manual `~/.config/CrossOver` deletion.

## Why not more?

PR #506 already added the GPU-safe boot path for `--reset` on Linux, which was the load-bearing fix for #450. This PR is the follow-up: catch the last-mile launcher edge case (argv fallback) and document what users on Mint / Nobara / Silverblue actually need to do.

Deeper distro-specific bugs (Wayland transparency native-fix, Vulkan overlay injection) are out of scope — they'd need a compositor/Vulkan-layer approach that's much larger than a bug-fix PR.

## Test plan

- [ ] `node -c src/main.js` clean (verified locally)
- [ ] Manual: `crossover --reset` on Linux clears preferences
- [ ] Manual: `CROSSOVER_RESET=1 crossover` still triggers reset (regression)
- [ ] Manual: normal launch (no flag) unaffected
- [ ] CI: lint + Playwright