### PR TITLE
fix(ci): publish snap to Snap Store via snapcraft upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,14 @@ jobs:
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic
 
-      - name: Build and publish snap
+      - name: Build snap and upload to GitHub release
+        # snapStore publish happens in the next step — electron-builder's bundled
+        # app-builder still calls `snapcraft push`, removed in modern snapcraft
         run: npx electron-builder --linux snap --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish snap to Snap Store
+        run: snapcraft upload --release=stable dist/*.snap
+        env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/package.json
+++ b/package.json
@@ -174,8 +174,7 @@
         "removable-media"
       ],
       "publish": [
-        "github",
-        "snapStore"
+        "github"
       ]
     },
     "win": {


### PR DESCRIPTION
## Summary

The v3.4.4 release run ([31918577355](https://github.com/lacymorrow/crossover/actions/runs/31918577355)) failed only in the `release-snap` job: electron-builder 24's bundled app-builder invokes `snapcraft push`, which modern snapcraft removed (exit 64, renamed to `upload`). The snap built fine; publishing died.

## Changes
- `package.json`: drop `snapStore` from `build.snap.publish` — electron-builder now only uploads the .snap to the GitHub release (which works).
- `.github/workflows/release.yml`: add an explicit `snapcraft upload --release=stable dist/*.snap` step using `SNAPCRAFT_STORE_CREDENTIALS`, bypassing app-builder's outdated `push` invocation.

## Testing notes
- Snap build itself already succeeded in the failed run; only the store-publish command changed.
- Will be exercised by re-pointing the `v3.4.4` tag after merge (release is still an unpublished draft, so re-running the workflow is safe).

Part of LAC-919 (ship #486/#450 fixes in v3.4.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)