### PR TITLE
fix(ci): publish snap to Snap Store via snapcraft upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,15 @@ jobs:
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic
 
-      - name: Build and publish snap
+      - name: Build snap and attach to GitHub release
         run: npx electron-builder --linux snap --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # app-builder-bin still runs the removed `snapcraft push` (exit 64 on
+      # snapcraft >=8), so upload to the Snap Store directly instead of via
+      # electron-builder's snapStore publisher.
+      - name: Publish snap to Snap Store
+        run: snapcraft upload --release=stable dist/*.snap
+        env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/package.json
+++ b/package.json
@@ -174,8 +174,7 @@
         "removable-media"
       ],
       "publish": [
-        "github",
-        "snapStore"
+        "github"
       ]
     },
     "win": {


### PR DESCRIPTION
Fixes the release-snap job failure from the v3.4.5 run (32905478508), also present on v3.4.4.

## Problem
app-builder-bin's snapStore publisher shells out to `snapcraft push` (`pkg/package-format/snap/snapStore.go:35`). Snapcraft 8 removed `push` in favor of `upload`, so the publish step exits 64 after a successful snap build, and no `.snap` asset lands on the release.

## Fix
- Remove `snapStore` from the snap publish config in package.json, leaving `github` so electron-builder attaches the `.snap` to the GitHub release.
- Add a workflow step that uploads to the Snap Store directly with `snapcraft upload --release=stable dist/*.snap`, the same command as the existing `snap:release` npm script. Uses the modern CLI, so no electron-builder bump or snapcraft pin needed.

Verification: package.json parses, workflow YAML lints clean. Real verification happens on the next tag push; the job is unchanged up through the snap build, which already passed on v3.4.5.

Paperclip: LACA-1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)