### PR TITLE
fix: defer session permission handlers until app ready (#529)

### DIFF
--- a/src/main/register.js
+++ b/src/main/register.js
@@ -1,4 +1,4 @@
-const { app, session } = require( 'electron' )
+const { app } = require( 'electron' )
 const { is } = require( './util' )
 const crossover = require( './crossover' )
 const preferences = require( './preferences' ).init()
@@ -6,21 +6,14 @@ const iohook = require( './iohook' )
 const keyboard = require( './keyboard' )
 const log = require( './log' )
 const reset = require( './reset' )
+const sessionPermissions = require( './session-permissions' )
 const windows = require( './windows' )
 const EXIT_CODES = require( '../config/exit-codes' )
 
 const appEvents = () => {
 
-	// CrossOver only renders local files and needs no browser permissions.
-	// Deny all permission requests (geolocation, notifications, camera, etc.)
-	// to prevent unexpected OS prompts, particularly on Windows. (#471)
-	session.defaultSession.setPermissionRequestHandler( ( _webContents, _permission, callback ) => {
-
-		callback( false )
-
-	} )
-
-	session.defaultSession.setPermissionCheckHandler( () => false )
+	// Deferred until app ready internally; appEvents() runs pre-ready (#529)
+	sessionPermissions.init()
 
 	app.on( 'activate', async () => {
 

--- a/src/main/session-permissions.js
+++ b/src/main/session-permissions.js
@@ -1,0 +1,20 @@
+const { app, session } = require( 'electron' )
+
+// CrossOver only renders local files and needs no browser permissions.
+// Deny all permission requests (geolocation, notifications, camera, etc.)
+// to prevent unexpected OS prompts, particularly on Windows. (#471)
+// Accessing session.defaultSession before the 'ready' event throws and
+// crashes the main process, so installation always defers until ready. (#529)
+const init = () => app.whenReady().then( () => {
+
+	session.defaultSession.setPermissionRequestHandler( ( _webContents, _permission, callback ) => {
+
+		callback( false )
+
+	} )
+
+	session.defaultSession.setPermissionCheckHandler( () => false )
+
+} )
+
+module.exports = { init }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -2,22 +2,7 @@ const fs = require( 'fs' )
 const path = require( 'path' )
 const { expect, test } = require( '@playwright/test' )
 const config = require( '../src/config/config.js' )
-
-const SRC_DIR = path.resolve( 'src' )
-
-const collectSourceFiles = dir => fs.readdirSync( dir, { withFileTypes: true } )
-	.flatMap( entry => {
-
-		const fullPath = path.join( dir, entry.name )
-		if ( entry.isDirectory() ) {
-
-			return collectSourceFiles( fullPath )
-
-		}
-
-		return entry.name.endsWith( '.js' ) ? [ fullPath ] : []
-
-	} )
+const { SRC_DIR, collectSourceFiles } = require( './helpers.js' )
 
 // Regression test for #529: menu.js destructured TROUBLESHOOTING_URL and
 // COMPATIBILITY_URL from config.js before they existed, crashing the main

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,27 @@
+const fs = require( 'fs' )
+const path = require( 'path' )
 const { _electron: electron } = require( 'playwright' )
 
 let electronApp
 
 const CHOOSER_WINDOW = 'Crosshairs'
 const SETTINGS_WINDOW = 'Preferences'
+
+const SRC_DIR = path.resolve( 'src' )
+
+const collectSourceFiles = dir => fs.readdirSync( dir, { withFileTypes: true } )
+	.flatMap( entry => {
+
+		const fullPath = path.join( dir, entry.name )
+		if ( entry.isDirectory() ) {
+
+			return collectSourceFiles( fullPath )
+
+		}
+
+		return entry.name.endsWith( '.js' ) ? [ fullPath ] : []
+
+	} )
 
 const delays = {
 	short: 500,
@@ -195,7 +213,9 @@ const visualMouse = async mainPage => {
 module.exports = {
 	CHOOSER_WINDOW,
 	SETTINGS_WINDOW,
+	SRC_DIR,
 	closeApp,
+	collectSourceFiles,
 	delays,
 	focusedMinimizedVisible,
 	getBounds,

--- a/test/session-permissions.spec.js
+++ b/test/session-permissions.spec.js
@@ -1,6 +1,7 @@
 const fs = require( 'fs' )
 const path = require( 'path' )
 const { expect, test } = require( '@playwright/test' )
+const { SRC_DIR, collectSourceFiles } = require( './helpers.js' )
 
 // Regression tests for #529 (startup race): appEvents() ran before
 // app.whenReady() and touched session.defaultSession to install the
@@ -10,7 +11,6 @@ const { expect, test } = require( '@playwright/test' )
 // the race. The handlers must always be installed via a whenReady()
 // deferral (src/main/session-permissions.js).
 
-const SRC_DIR = path.resolve( 'src' )
 const MODULE_PATH = require.resolve( '../src/main/session-permissions.js' )
 
 // Minimal stand-in for Electron that reproduces the real semantics the
@@ -33,37 +33,33 @@ const loadWithFakeElectron = () => {
 
 	const fakeElectron = {
 		app: {
-			isReady: () => ready,
 			whenReady: () => readyPromise,
-			on() {},
 		},
-		session: {},
+		session: {
+			get defaultSession() {
+
+				if ( !ready ) {
+
+					throw new Error( 'Session can only be received when app is ready' )
+
+				}
+
+				return {
+					setPermissionRequestHandler( handler ) {
+
+						handlers.request = handler
+
+					},
+					setPermissionCheckHandler( handler ) {
+
+						handlers.check = handler
+
+					},
+				}
+
+			},
+		},
 	}
-
-	Object.defineProperty( fakeElectron.session, 'defaultSession', {
-		get() {
-
-			if ( !ready ) {
-
-				throw new Error( 'Session can only be received when app is ready' )
-
-			}
-
-			return {
-				setPermissionRequestHandler( handler ) {
-
-					handlers.request = handler
-
-				},
-				setPermissionCheckHandler( handler ) {
-
-					handlers.check = handler
-
-				},
-			}
-
-		},
-	} )
 
 	const electronPath = require.resolve( 'electron' )
 	const previous = require.cache[electronPath]
@@ -73,7 +69,6 @@ const loadWithFakeElectron = () => {
 		loaded: true,
 		exports: fakeElectron,
 	}
-	delete require.cache[MODULE_PATH]
 
 	try {
 
@@ -101,15 +96,7 @@ const loadWithFakeElectron = () => {
 
 }
 
-test( 'init() before app is ready must not throw', async () => {
-
-	const { sessionPermissions } = loadWithFakeElectron()
-
-	expect( () => sessionPermissions.init() ).not.toThrow()
-
-} )
-
-test( 'Handlers are installed after ready and deny all permissions', async () => {
+test( 'init() before app is ready must not throw; handlers install after ready and deny all', async () => {
 
 	const { sessionPermissions, handlers, resolveReady } = loadWithFakeElectron()
 
@@ -133,20 +120,6 @@ test( 'Handlers are installed after ready and deny all permissions', async () =>
 } )
 
 test( 'session.defaultSession is only accessed by session-permissions.js', async () => {
-
-	const collectSourceFiles = dir => fs.readdirSync( dir, { withFileTypes: true } )
-		.flatMap( entry => {
-
-			const fullPath = path.join( dir, entry.name )
-			if ( entry.isDirectory() ) {
-
-				return collectSourceFiles( fullPath )
-
-			}
-
-			return entry.name.endsWith( '.js' ) ? [ fullPath ] : []
-
-		} )
 
 	for ( const file of collectSourceFiles( SRC_DIR ) ) {
 

--- a/test/session-permissions.spec.js
+++ b/test/session-permissions.spec.js
@@ -1,0 +1,164 @@
+const fs = require( 'fs' )
+const path = require( 'path' )
+const { expect, test } = require( '@playwright/test' )
+
+// Regression tests for #529 (startup race): appEvents() ran before
+// app.whenReady() and touched session.defaultSession to install the
+// deny-all permission handlers from #493. Electron throws "Session can
+// only be received when app is ready" on pre-ready access, crashing the
+// main process before any window or tray exists on machines that lose
+// the race. The handlers must always be installed via a whenReady()
+// deferral (src/main/session-permissions.js).
+
+const SRC_DIR = path.resolve( 'src' )
+const MODULE_PATH = require.resolve( '../src/main/session-permissions.js' )
+
+// Minimal stand-in for Electron that reproduces the real semantics the
+// bug depends on: defaultSession throws until the app is ready.
+const loadWithFakeElectron = () => {
+
+	const handlers = {}
+	let ready = false
+	let resolveReady
+	const readyPromise = new Promise( resolve => {
+
+		resolveReady = () => {
+
+			ready = true
+			resolve()
+
+		}
+
+	} )
+
+	const fakeElectron = {
+		app: {
+			isReady: () => ready,
+			whenReady: () => readyPromise,
+			on() {},
+		},
+		session: {},
+	}
+
+	Object.defineProperty( fakeElectron.session, 'defaultSession', {
+		get() {
+
+			if ( !ready ) {
+
+				throw new Error( 'Session can only be received when app is ready' )
+
+			}
+
+			return {
+				setPermissionRequestHandler( handler ) {
+
+					handlers.request = handler
+
+				},
+				setPermissionCheckHandler( handler ) {
+
+					handlers.check = handler
+
+				},
+			}
+
+		},
+	} )
+
+	const electronPath = require.resolve( 'electron' )
+	const previous = require.cache[electronPath]
+	require.cache[electronPath] = {
+		id: electronPath,
+		filename: electronPath,
+		loaded: true,
+		exports: fakeElectron,
+	}
+	delete require.cache[MODULE_PATH]
+
+	try {
+
+		return {
+			sessionPermissions: require( '../src/main/session-permissions.js' ),
+			handlers,
+			resolveReady,
+		}
+
+	} finally {
+
+		if ( previous ) {
+
+			require.cache[electronPath] = previous
+
+		} else {
+
+			delete require.cache[electronPath]
+
+		}
+
+		delete require.cache[MODULE_PATH]
+
+	}
+
+}
+
+test( 'init() before app is ready must not throw', async () => {
+
+	const { sessionPermissions } = loadWithFakeElectron()
+
+	expect( () => sessionPermissions.init() ).not.toThrow()
+
+} )
+
+test( 'Handlers are installed after ready and deny all permissions', async () => {
+
+	const { sessionPermissions, handlers, resolveReady } = loadWithFakeElectron()
+
+	const installed = sessionPermissions.init()
+
+	expect( handlers.request, 'must not touch defaultSession before ready' ).toBeUndefined()
+
+	resolveReady()
+	await installed
+
+	let granted = null
+	handlers.request( null, 'notifications', allowed => {
+
+		granted = allowed
+
+	} )
+
+	expect( granted, 'permission requests must be denied' ).toBe( false )
+	expect( handlers.check(), 'permission checks must be denied' ).toBe( false )
+
+} )
+
+test( 'session.defaultSession is only accessed by session-permissions.js', async () => {
+
+	const collectSourceFiles = dir => fs.readdirSync( dir, { withFileTypes: true } )
+		.flatMap( entry => {
+
+			const fullPath = path.join( dir, entry.name )
+			if ( entry.isDirectory() ) {
+
+				return collectSourceFiles( fullPath )
+
+			}
+
+			return entry.name.endsWith( '.js' ) ? [ fullPath ] : []
+
+		} )
+
+	for ( const file of collectSourceFiles( SRC_DIR ) ) {
+
+		if ( path.resolve( file ) === MODULE_PATH ) {
+
+			continue
+
+		}
+
+		const source = fs.readFileSync( file, 'utf8' )
+		expect( source.includes( 'defaultSession' ), `${path.relative( SRC_DIR, file )} must not access defaultSession directly — use session-permissions.js, which defers until app ready (#529)` ).toBe( false )
+
+	}
+
+} )


### PR DESCRIPTION
## Summary

Fixes the second startup crash reported in #529 ([joncl's report](https://github.com/lacymorrow/crossover/issues/529#issuecomment-3336458428)): on some machines, 3.4.1/3.4.4/3.4.5 launch as a single orphaned process with no window and no tray icon, with `TypeError: Session can only be received when app is ready` in `main.log`.

**Root cause:** `src/main.js` calls `register.appEvents()` *before* `await app.whenReady()`, and `appEvents()` immediately touched `session.defaultSession` to install the deny-all permission handlers added in #493. Electron throws if `defaultSession` is accessed before the `ready` event, killing the main process before any UI exists. Whether it crashes is a startup-timing race (module load + init vs. Electron's `ready` event), which is why it reproduces consistently on some machines and never on others.

**Fix:** the handlers now live in `src/main/session-permissions.js`, which always defers installation behind `app.whenReady()`. Handler behavior is unchanged (deny all permission requests/checks); they are installed before any window is created (windows are created 500ms after ready).

Paperclip issue: LAC-3530 (follow-up to LAC-3424 / v3.4.5).

## Testing

- **Regression test** (`test/session-permissions.spec.js`): a minimal fake Electron reproduces the real semantics — `defaultSession` throws until ready. The main test fails on the old synchronous installation (verified red before the fix) and asserts the handlers install after ready and deny all permissions. A guard test keeps direct `defaultSession` access from being reintroduced anywhere else in `src/` (the shared source-tree walker moved into `test/helpers.js`, reused by `config.spec.js`).
- `npx playwright test test/session-permissions.spec.js test/config.spec.js` — 4/4 pass.
- Booted the app locally with the fix: clean startup, `App ready`, window created, no session errors after 12s.
- `npm run lint` clean (0 errors) on changed files.
- Note: the full Playwright app-launch suite times out in this environment on unmodified `main` too (10s `beforeAll` hook budget) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
