### PR TITLE
chore(release): bump to 3.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "crossover",
   "productName": "CrossOver",
   "appId": "com.lacymorrow.crossover",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "A Crosshair Overlay for any screen",
   "copyright": "Copyright \u00a9 Lacy Morrow",
   "repository": {


### PR DESCRIPTION
Version bump for the 3.4.6 patch release.

Ships the fix from #532 (LAC-3530): startup race where `session.defaultSession` was accessed before `app` ready, leaving the app as a single orphaned process with no window or tray icon (reported by @joncl in #529).

After merge, tag `v3.4.6` triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)